### PR TITLE
Fix broken URL in dapperfile

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,8 +5,8 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
 RUN zypper -n install git docker vim less file curl wget
 
-RUN if [ "${ARCH}" == "amd64" ]; then \
-        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.41.1; \
+RUN if [[ "${ARCH}" == "amd64" ]]; then \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2; \
     fi
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG


### PR DESCRIPTION
Replaces the deprecated goreleaser URL in the dapper file with the updated URL as outlined in this [task](https://github.com/rancher/tasks/issues/203)