### PR TITLE
 Migrate from Drone to GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-## (5b) Pin to commits, not tags
-
 name: CI Build and Check
 
 on:
@@ -67,7 +65,7 @@ jobs:
     - name: Determine Tag
       id: get-TAG
       run: |
-        export TAG=g$(git describe --always)
+        export TAG=$(git describe --always)
         echo "TAG=$TAG"
         echo "TAG=$TAG" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,107 @@
+## (5b) Pin to commits, not tags
+
+name: CI Build and Check
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  IMAGE: rancher/kube-api-auth
+
+permissions:
+  contents: read
+  security-events: write # upload Trivy Sarif results
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Sources
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: false
+
+    - name: Validate the sources
+      run: |
+        ./scripts/validate
+        # Except for linting. That is done through the proper GH action
+
+    - name: Lint sources
+      uses: golangci/golangci-lint-action@v4
+
+    - name: Test
+      run: ./scripts/test
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - linter
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+    - name: Prepare Matrix Instance
+      run: |
+        platform=${{ matrix.platform }}
+        export GOOS="$(echo ${platform}   | sed -e 's|/.*||')"
+        export GOARCH="$(echo ${platform} | sed -e 's|.*/||')"
+        export ARCH="$GOARCH"
+        echo "GOOS=$GOOS"     >> $GITHUB_ENV
+        echo "GOARCH=$GOARCH" >> $GITHUB_ENV
+        echo "ARCH=$ARCH"     >> $GITHUB_ENV
+
+    - name: Get Sources
+      uses: actions/checkout@v3
+
+    - name: Determine Tag
+      id: get-TAG
+      run: |
+        export TAG=g$(git describe --always)
+        echo "TAG=$TAG"
+        echo "TAG=$TAG" >> "$GITHUB_ENV"
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: false
+
+    - name: Build
+      run: |
+        ./scripts/build
+        echo Stage binary for packaging step
+        cp -rv ./bin/* ./package/
+
+    - name: Package up into container image
+      uses: docker/build-push-action@v5
+      with:
+        context: package
+        push: false
+        tags: ${{ env.IMAGE }}:${{ env.TAG }}-${{ env.ARCH }}
+        file: package/Dockerfile
+
+    - name: Scan for security vulnerabilities using Trivy
+      uses: aquasecurity/trivy-action@0.18.0
+      with:
+        image-ref: ${{ env.IMAGE }}:${{ env.TAG }}-${{ env.ARCH }}
+        ignore-unfixed: true
+        vuln-type: 'os,library'
+        severity: 'CRITICAL,HIGH'
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,19 +46,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        os:
+          - linux
+        arch:
+          - amd64
+          - arm64
     steps:
     - name: Prepare Matrix Instance
       run: |
-        platform=${{ matrix.platform }}
-        export GOOS="$(echo ${platform}   | sed -e 's|/.*||')"
-        export GOARCH="$(echo ${platform} | sed -e 's|.*/||')"
-        export ARCH="$GOARCH"
-        echo "GOOS=$GOOS"     >> $GITHUB_ENV
-        echo "GOARCH=$GOARCH" >> $GITHUB_ENV
-        echo "ARCH=$ARCH"     >> $GITHUB_ENV
+        echo "GOOS=${{ matrix.os }}"
+        echo "GOOS=${{ matrix.os }}"     >> $GITHUB_ENV
+        echo "GOARCH=${{ matrix.arch }}"
+        echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+        echo "ARCH=${{ matrix.arch }}"
+        echo "ARCH=${{ matrix.arch }}"   >> $GITHUB_ENV
 
     - name: Get Sources
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,148 @@
+## (5b) Pin to commits, not tags
+
+name: CI Build And Publish Release
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+env:
+  IMAGE: rancher/kube-api-auth
+
+jobs:
+  push:
+    permissions:
+      contents: read
+      id-token: write # this is important, it's how we authenticate with Vault
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Prepare Matrix Instance
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Retrieve Docker Hub Credentials From Vault
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_PASSWORD }}
+
+      - name: Get Sources
+        uses: actions/checkout@v4
+
+      - name: Docker Meta Data Setup
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: false
+
+      - name: Build and stage
+        run: |
+          case "${{ matrix.platform }}" in
+          */arm64) export ARCH=arm64 ; export GOARCH=arm64 ;;
+          *)       export ARCH=amd64 ; export GOARCH=amd64 ;;
+          esac
+          ./scripts/build
+          # Stage binary for packaging step
+          cp -r ./bin/* ./package/
+
+      - name: Build image and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: package
+          file: package/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    permissions:
+      contents: read
+      id-token: write # this is important, it's how we authenticate with Vault
+    runs-on: ubuntu-latest
+    needs:
+      - push
+    steps:
+      - name: Retrieve Docker Hub Credentials From Vault
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_PASSWORD }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,3 @@
-## (5b) Pin to commits, not tags
-
 name: CI Build And Publish Release
 
 on:
@@ -70,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
           cache: false
 
       - name: Build and stage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        os:
+          - linux
+        arch:
+          - amd64
+          - arm64
     steps:
       - name: Prepare Matrix Instance
         run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=${{ matrix.os }}-${{ matrix.arch }}"
+          echo "PLATFORM_PAIR=${{ matrix.os }}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "GOOS=${{ matrix.os }}"
+          echo "GOOS=${{ matrix.os }}"     >> $GITHUB_ENV
+          echo "GOARCH=${{ matrix.arch }}"
+          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "ARCH=${{ matrix.arch }}"
+          echo "ARCH=${{ matrix.arch }}"   >> $GITHUB_ENV
 
       - name: Retrieve Docker Hub Credentials From Vault
         uses: rancher-eio/read-vault-secrets@main
@@ -67,10 +75,6 @@ jobs:
 
       - name: Build and stage
         run: |
-          case "${{ matrix.platform }}" in
-          */arm64) export ARCH=arm64 ; export GOARCH=arm64 ;;
-          *)       export ARCH=amd64 ; export GOARCH=amd64 ;;
-          esac
           ./scripts/build
           # Stage binary for packaging step
           cp -r ./bin/* ./package/
@@ -81,7 +85,7 @@ jobs:
         with:
           context: package
           file: package/Dockerfile
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.os }}/${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
 


### PR DESCRIPTION
Fix https://github.com/rancher/rancher/issues/44988

Added draft GHA flows for test builds, and publication.

:construction: :warning: :warning: :construction:
- [x]  Test the flows. Although unclear how to do that for the publication flow. The problem is less that it cannot be triggered for testing, enabling manual triggers handles that nicely. The issue is that the flow will push non-release images to the docker hub, which is very much not desired. That said, it also requires secrets, which we do not have yet.
- [ ] Remove Drone spec

Ref https://github.com/rancherlabs/eio/issues/2165 for the migration of associated secrets

See https://hub.docker.com/r/rancher/kube-api-auth/tags
for where the images live on Docker Hub.

---

The publication flow (`release.yml`) was tested with PR #25.
The flow added here differs only in the trigger condition.
The test flow triggered on `push_request` whereas this here triggers on `published release`.

The action logs of the test run are at https://github.com/rancher/kube-api-auth/actions/runs/8738114342

The resulting image is at https://hub.docker.com/layers/rancher/kube-api-auth/pr-25/images/sha256-9f13ef730a7683a7eb91f1258d0129d5000a43c762605e234aa142d8f2a6d2fc
Its tag is `pr-25`, which was automatically chosen by the `docker/metadata-action@v5`, and is hopefully different enough to not be mistaken for a released version.


