### PR TITLE
Bump Go to 1.23.1

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @rancher/collie

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.21
+FROM registry.suse.com/bci/golang:1.23
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
@@ -6,7 +6,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 RUN zypper -n install git docker vim less file curl wget
 
 RUN if [[ "${ARCH}" == "amd64" ]]; then \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.54.2; \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.61.0; \
     fi
 
 ENV DAPPER_ENV REPO TAG

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-kube-api-auth
-========
+# kube-api-auth
 
 A microservice for user authentication in kubernetes clusters.
 
@@ -12,11 +11,13 @@ A microservice for user authentication in kubernetes clusters.
 `./bin/kube-api-auth`
 
 ## Contact
+
 For bugs, questions, comments, corrections, suggestions, etc., open an issue in rancher/rancher with a title starting with `[kube-api-auth]`.
 
 Or just [click here](//github.com/rancher/rancher/issues/new?title=%5Bkube-api-auth%5D%20) to create a new issue.
 
 ## License
+
 Copyright (c) 2019 [Rancher Labs, Inc.](http://rancher.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/kube-api-auth
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.5
+toolchain go1.23.1
 
 replace (
 	github.com/docker/docker => github.com/docker/docker v20.10.27+incompatible // oras dep requires a replace is set

--- a/pkg/service/handlers/v1-kube-api-authn.go
+++ b/pkg/service/handlers/v1-kube-api-authn.go
@@ -56,7 +56,7 @@ func (kube *KubeAPIHandlers) v1Authenticate(w http.ResponseWriter, r *http.Reque
 		ReturnHTTPError(w, r, http.StatusServiceUnavailable, fmt.Sprintf("%v", err))
 		return
 	}
-	log.Infof(string(responseJSON))
+	log.Info(string(responseJSON))
 	log.Infof("  ...authenticated %s!", accessKey)
 }
 


### PR DESCRIPTION
The new stable BCI golang image `registry.suse.com/bci/golang:1.23` is now available.
Start building with Go 1.23 using the latest available toolchain in the BCI image.