### PR TITLE
Use CMD exec form

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -11,4 +11,4 @@ COPY kube-api-auth /usr/bin/
 
 USER $user
 
-CMD kube-api-auth serve
+CMD ["kube-api-auth", "serve"]


### PR DESCRIPTION
```
1 warning found (use docker --debug to expand):
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 14)
```