### PR TITLE
Bump Go toolchain to 1.23.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/kube-api-auth
 
-go 1.23.0
+go 1.23.4
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 replace (
 	github.com/docker/docker => github.com/docker/docker v20.10.27+incompatible // oras dep requires a replace is set

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/kube-api-auth
 
 go 1.23.4
 
-toolchain go1.23.6
+toolchain go1.23.7
 
 replace (
 	github.com/docker/docker => github.com/docker/docker v20.10.27+incompatible // oras dep requires a replace is set


### PR DESCRIPTION
Match `bci/golang:1.23` image and rancher/rancher.