### PR TITLE
Update bci/bci-micro image to 15.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/kube-api-auth
 
 go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.5
 
 replace (
 	github.com/docker/distribution => github.com/docker/distribution v2.8.2+incompatible

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-micro:15.6
+FROM registry.suse.com/bci/bci-micro:15.7
 
 ARG user=kubeapiauth
 


### PR DESCRIPTION
- Update bci/bci-micro image to 15.7 to align with other Rancher release artifacts (rancher, webhook).
- Update Go toolchain to 1.24.5