### PR TITLE
Bump Go toolchain to 1.24.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/kube-api-auth
 
 go 1.24.0
 
-toolchain go1.24.7
+toolchain go1.24.9
 
 replace (
 	github.com/docker/distribution => github.com/docker/distribution v2.8.2+incompatible


### PR DESCRIPTION
```
docker inspect registry.suse.com/bci/golang:1.24 | grep GOLANG_VERSION
                "GOLANG_VERSION=1.24.9",
```