### PR TITLE
Bump trivy CI action to the latest available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         file: package/Dockerfile
 
     - name: Scan for security vulnerabilities using Trivy
-      uses: aquasecurity/trivy-action@0.18.0
+      uses: aquasecurity/trivy-action@0.34.0
       with:
         image-ref: ${{ env.IMAGE }}:${{ env.TAG }}-${{ env.ARCH }}
         ignore-unfixed: true


### PR DESCRIPTION
It seems the previous version is no longer compatible with the new Docker version installed in the runners:
```
2026-02-13T10:48:38.880Z	FATAL	image scan error: scan error: unable to initialize a scanner: unable to initialize an image scanner: 4 errors occurred:
	* docker error: unable to inspect the image (rancher/kube-api-auth:112407c-amd64): Error response from daemon: client version 1.43 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version
```