### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GOLANG_CI_LINT_VERSION: v2.7.2
   IMAGE: rancher/kube-api-auth
@@ -19,6 +23,8 @@ jobs:
     steps:
     - name: Get Sources
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -57,23 +63,29 @@ jobs:
           - arm64
     steps:
     - name: Prepare Matrix Instance
+      id: prepare
+      env:
+        GOOS: ${{ matrix.os }}
+        GOARCH: ${{ matrix.arch }}
       run: |
-        echo "GOOS=${{ matrix.os }}"
-        echo "GOOS=${{ matrix.os }}"     >> $GITHUB_ENV
-        echo "GOARCH=${{ matrix.arch }}"
-        echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-        echo "ARCH=${{ matrix.arch }}"
-        echo "ARCH=${{ matrix.arch }}"   >> $GITHUB_ENV
+        echo "GOOS=$GOOS"
+        echo "GOOS=$GOOS"     >> "$GITHUB_OUTPUT"
+        echo "GOARCH=$GOARCH"
+        echo "GOARCH=$GOARCH" >> "$GITHUB_OUTPUT"
+        echo "ARCH=$GOARCH"
+        echo "ARCH=$GOARCH"   >> "$GITHUB_OUTPUT"
 
     - name: Get Sources
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      with:
+        persist-credentials: false
 
     - name: Determine Tag
       id: get-TAG
       run: |
-        export TAG=$(git describe --always)
+        TAG=$(git describe --always)
         echo "TAG=$TAG"
-        echo "TAG=$TAG" >> "$GITHUB_ENV"
+        echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -82,6 +94,9 @@ jobs:
         cache: false
 
     - name: Build
+      env:
+        GOOS: ${{ steps.prepare.outputs.GOOS }}
+        GOARCH: ${{ steps.prepare.outputs.GOARCH }}
       run: |
         ./scripts/build
         echo Stage binary for packaging step
@@ -92,5 +107,5 @@ jobs:
       with:
         context: package
         push: false
-        tags: ${{ env.IMAGE }}:${{ env.TAG }}-${{ env.ARCH }}
+        tags: ${{ env.IMAGE }}:${{ steps.get-TAG.outputs.TAG }}-${{ steps.prepare.outputs.ARCH }}
         file: package/Dockerfile

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      with:
+        persist-credentials: false
 
     # The FOSSA token is shared between all repos in Rancher's GH org. It can be
     # used directly and there is no need to request specific access to EIO.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,19 @@ jobs:
           - arm64
     steps:
       - name: Prepare Matrix Instance
+        id: prepare
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
         run: |
-          echo "PLATFORM_PAIR=${{ matrix.os }}-${{ matrix.arch }}"
-          echo "PLATFORM_PAIR=${{ matrix.os }}-${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "GOOS=${{ matrix.os }}"
-          echo "GOOS=${{ matrix.os }}"     >> $GITHUB_ENV
-          echo "GOARCH=${{ matrix.arch }}"
-          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "ARCH=${{ matrix.arch }}"
-          echo "ARCH=${{ matrix.arch }}"   >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=$GOOS-$GOARCH"
+          echo "PLATFORM_PAIR=$GOOS-$GOARCH" >> "$GITHUB_OUTPUT"
+          echo "GOOS=$GOOS"
+          echo "GOOS=$GOOS"     >> "$GITHUB_OUTPUT"
+          echo "GOARCH=$GOARCH"
+          echo "GOARCH=$GOARCH" >> "$GITHUB_OUTPUT"
+          echo "ARCH=$GOARCH"
+          echo "ARCH=$GOARCH"   >> "$GITHUB_OUTPUT"
 
       - name: Retrieve Docker Hub Credentials From Vault
         uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
@@ -52,6 +56,8 @@ jobs:
 
       - name: Get Sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Docker Meta Data Setup
         id: meta
@@ -72,6 +78,9 @@ jobs:
           cache: false
 
       - name: Build and stage
+        env:
+          GOOS: ${{ steps.prepare.outputs.GOOS }}
+          GOARCH: ${{ steps.prepare.outputs.GOARCH }}
         run: |
           ./scripts/build
           # Stage binary for packaging step
@@ -88,15 +97,16 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ steps.prepare.outputs.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -143,8 +153,10 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+            $(printf "${IMAGE}@sha256:%s " *)
 
       - name: Inspect image
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}"


### PR DESCRIPTION
- Add concurrency group to ci.yml to cancel stale runs
- Add persist-credentials: false to all actions/checkout steps
- Replace $GITHUB_ENV with $GITHUB_OUTPUT for inter-step data
- Bind ${{ }} template expressions to env: vars to prevent script injection in run: blocks