### PR TITLE
Handle ext.Tokens

### DIFF
--- a/pkg/service/handlers/v1-kube-api-authn.go
+++ b/pkg/service/handlers/v1-kube-api-authn.go
@@ -77,7 +77,7 @@ func v1parseBody(r *http.Request) (string, string, error) {
 		return "", "", fmt.Errorf("found %d parts of token", len(tokenParts))
 	}
 
-	accessKey := tokenParts[0]
+	accessKey := strings.TrimPrefix(tokenParts[0], "ext/")
 	secretKey := tokenParts[1]
 
 	return accessKey, secretKey, nil

--- a/pkg/service/handlers/v1-kube-api-authn_test.go
+++ b/pkg/service/handlers/v1-kube-api-authn_test.go
@@ -1,0 +1,93 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	kubeapiauth "github.com/rancher/kube-api-auth/pkg"
+	"github.com/rancher/kube-api-auth/pkg/api/v1/types"
+)
+
+func TestV1parseBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		token      string
+		wantKey    string
+		wantSecret string
+		wantErr    bool
+	}{
+		{
+			name:       "legacy token",
+			token:      "tokenName:secretValue",
+			wantKey:    "tokenName",
+			wantSecret: "secretValue",
+		},
+		{
+			name:       "ext token",
+			token:      "ext/token-abc123:secretValue",
+			wantKey:    "token-abc123",
+			wantSecret: "secretValue",
+		},
+		{
+			name:       "ext token with colon in secret",
+			token:      "ext/token-abc123:secret:with:colons",
+			wantKey:    "token-abc123",
+			wantSecret: "secret:with:colons",
+		},
+		{
+			name:       "legacy token with colon in secret",
+			token:      "tokenName:secret:with:colons",
+			wantKey:    "tokenName",
+			wantSecret: "secret:with:colons",
+		},
+		{
+			name:    "missing colon",
+			token:   "tokenNameOnly",
+			wantErr: true,
+		},
+		{
+			name:    "empty token",
+			token:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := types.V1AuthnRequest{
+				APIVersion: kubeapiauth.DefaultK8sAPIVersion,
+				Kind:       kubeapiauth.DefaultAuthnKind,
+				Spec:       types.V1AuthnRequestSpec{Token: tt.token},
+			}
+			data, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("failed to marshal request: %v", err)
+			}
+
+			r := httptest.NewRequest("POST", "/v1/authenticate", bytes.NewReader(data))
+			accessKey, secretKey, err := v1parseBody(r)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got accessKey=%q secretKey=%q", accessKey, secretKey)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if accessKey != tt.wantKey {
+				t.Errorf("accessKey = %q, want %q", accessKey, tt.wantKey)
+			}
+			if secretKey != tt.wantSecret {
+				t.Errorf("secretKey = %q, want %q", secretKey, tt.wantSecret)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/55179

## Problem
Rancher migrated kubeconfig tokens from v3 Tokens to ext Tokens, which changed the bearer token format by adding an `ext/` prefix to the token name. The authentication webhook was using the prefixed name to look up the downstream cluster auth token resource, which doesn't carry the prefix, causing direct node context authentication to fail.

## Solution
Strip the prefix during token parsing so the resource lookup uses the correct name. Both legacy and ext token formats are now handled.