### PR TITLE
Record base image tag and digest on built images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,22 @@ jobs:
         echo Stage binary for packaging step
         cp -rv ./bin/* ./package/
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+    - name: Resolve BCI base image
+      id: bci
+      env:
+        BASE_TAG: registry.suse.com/bci/bci-micro:15.7
+      run: |
+        DIGEST=$(docker buildx imagetools inspect "$BASE_TAG" \
+          --format '{{.Manifest.Digest}}')
+        REF=$(docker buildx imagetools inspect "$BASE_TAG" --format '{{json .Image}}' \
+          | jq -er '[.[].config.Labels."org.opensuse.reference"] | unique
+              | if length == 1 then .[0] else error("base image ref differs across platforms") end')
+        echo "BASE_IMAGE=$REF"     >> "$GITHUB_OUTPUT"
+        echo "BASE_DIGEST=$DIGEST" >> "$GITHUB_OUTPUT"
+
     - name: Package up into container image
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
@@ -109,3 +125,6 @@ jobs:
         push: false
         tags: ${{ env.IMAGE }}:${{ steps.get-TAG.outputs.TAG }}-${{ steps.prepare.outputs.ARCH }}
         file: package/Dockerfile
+        build-args: |
+          BASE_IMAGE=${{ steps.bci.outputs.BASE_IMAGE }}
+          BASE_DIGEST=${{ steps.bci.outputs.BASE_DIGEST }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,9 @@ jobs:
 
     - name: Resolve BCI base image
       id: bci
-      env:
-        BASE_TAG: registry.suse.com/bci/bci-micro:15.7
       run: |
+        BASE_TAG=$(awk -F= '/^ARG BASE_IMAGE=/ {print $2; exit}' package/Dockerfile)
+        [ -n "$BASE_TAG" ] || { echo "could not parse BASE_IMAGE from package/Dockerfile" >&2; exit 1; }
         DIGEST=$(docker buildx imagetools inspect "$BASE_TAG" \
           --format '{{.Manifest.Digest}}')
         REF=$(docker buildx imagetools inspect "$BASE_TAG" --format '{{json .Image}}' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,19 @@ jobs:
           # Stage binary for packaging step
           cp -r ./bin/* ./package/
 
+      - name: Resolve BCI base image
+        id: bci
+        env:
+          BASE_TAG: registry.suse.com/bci/bci-micro:15.7
+        run: |
+          DIGEST=$(docker buildx imagetools inspect "$BASE_TAG" \
+            --format '{{.Manifest.Digest}}')
+          REF=$(docker buildx imagetools inspect "$BASE_TAG" --format '{{json .Image}}' \
+            | jq -er '[.[].config.Labels."org.opensuse.reference"] | unique
+                | if length == 1 then .[0] else error("base image ref differs across platforms") end')
+          echo "BASE_IMAGE=$REF"     >> "$GITHUB_OUTPUT"
+          echo "BASE_DIGEST=$DIGEST" >> "$GITHUB_OUTPUT"
+
       - name: Build image and push by digest
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -94,6 +107,9 @@ jobs:
           file: package/Dockerfile
           platforms: ${{ matrix.os }}/${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=${{ steps.bci.outputs.BASE_IMAGE }}
+            BASE_DIGEST=${{ steps.bci.outputs.BASE_DIGEST }}
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,9 @@ jobs:
 
       - name: Resolve BCI base image
         id: bci
-        env:
-          BASE_TAG: registry.suse.com/bci/bci-micro:15.7
         run: |
+          BASE_TAG=$(awk -F= '/^ARG BASE_IMAGE=/ {print $2; exit}' package/Dockerfile)
+          [ -n "$BASE_TAG" ] || { echo "could not parse BASE_IMAGE from package/Dockerfile" >&2; exit 1; }
           DIGEST=$(docker buildx imagetools inspect "$BASE_TAG" \
             --format '{{.Manifest.Digest}}')
           REF=$(docker buildx imagetools inspect "$BASE_TAG" --format '{{json .Image}}' \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,11 @@
-FROM registry.suse.com/bci/bci-micro:15.7
+ARG BASE_IMAGE=registry.suse.com/bci/bci-micro:15.7
+ARG BASE_DIGEST
+
+FROM ${BASE_IMAGE}${BASE_DIGEST:+@${BASE_DIGEST}}
 
 ARG user=kubeapiauth
+ARG BASE_IMAGE
+ARG BASE_DIGEST
 
 RUN echo "$user:x:1000:1000::/home/$user:/bin/bash" >> /etc/passwd && \
     echo "$user:x:1000:" >> /etc/group && \
@@ -10,5 +15,8 @@ RUN echo "$user:x:1000:1000::/home/$user:/bin/bash" >> /etc/passwd && \
 COPY kube-api-auth /usr/bin/
 
 USER $user
+
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE}" \
+      org.opencontainers.image.base.digest="${BASE_DIGEST}"
 
 CMD ["kube-api-auth", "serve"]


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/55461<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Published images carried no explicit record of which base image build they were produced against. The floating :15.7 tag is re-published as new patches ship, and the only trace of the actual base build came from labels that BCI happens to set and this Dockerfile happens not to override — fragile, and with no digest.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The Dockerfile now takes the base image reference and digest as build args, pins the FROM line by digest, and emits the standard OCI base-image labels. The CI and release workflows resolve the floating :15.7 tag to its manifest digest and pinned ref (e.g. 15.7-56.21) before each build and pass both in, so the labels always reflect what was actually pulled.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
