### PR TITLE
Document versioning strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ A microservice for user authentication in kubernetes clusters.
 
 `./bin/kube-api-auth`
 
+## Versioning
+
+`kube-api-auth` is released directly from git tags as an OCI image consumed by `rancher/rancher`. The `master` branch carries the leading edge; its minor version is bumped to match the lowest Rancher minor being introduced when a breaking change lands. Maintenance lines for older Rancher versions live on `release/v0.<MIN>` branches (where `<MIN>` is the lowest Rancher minor served by that line).
+
+See [VERSION.md](VERSION.md) for the current branch ↔ minor ↔ Rancher mapping and the full scheme.
+
 ## Contact
 
 For bugs, questions, comments, corrections, suggestions, etc., open an issue in rancher/rancher with a title starting with `[kube-api-auth]`.

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,0 +1,41 @@
+# Versioning
+
+`kube-api-auth` ships as an OCI image consumed by `rancher/rancher` and is
+released directly from git tags.
+
+The `master` branch carries the leading edge. The master minor is bumped to
+match the lowest Rancher minor the next release will serve — for example,
+master moves to `v0.13` when it starts tracking Rancher v2.13+. Tags on
+`master` are sequential patches within the minor: `v0.13.0`, `v0.13.1`, …
+
+Maintenance lines for Rancher versions no longer on master live on
+`release/v0.<MIN>` branches (where `<MIN>` is the lowest Rancher minor
+served by that line), cut from the initial `v0.<MIN>.0` tag. Tags on
+maintenance branches are sequential: `v0.<MIN>.0`, `v0.<MIN>.1`, …
+
+## Supported release lines
+
+Keep the table well-formed: one row per branch, columns in the order shown.
+
+| Branch              | Minor   | Rancher Versions     | Status |
+|---------------------|---------|----------------------|--------|
+| master              | v0.13   | v2.13, v2.14, v2.15  | active |
+| release/v0.10       | v0.10   | v2.10, v2.11, v2.12  | active |
+
+Status values: `active` (receives fixes), `eol` (no longer maintained). EOL
+rows stay in the table — they keep the historical mapping discoverable and
+let image-scanning tooling correlate old tags to the Rancher lines that
+shipped them.
+
+## Currently deployed tags
+
+Which kube-api-auth tag is consumed by the latest patch of each supported
+Rancher minor. Update this when a Rancher line bumps its
+`pkg/apis/management.cattle.io/v3/tools_system_images.go` pin. Superseded
+tags drop out (rancher/rancher git history of `tools_system_images.go` is
+authoritative for per-patch precision).
+
+| kube-api-auth Tag | Rancher Minors      |
+|-------------------|---------------------|
+| v0.2.6            | v2.13, v2.14, v2.15 |
+| v0.2.4            | v2.10, v2.11, v2.12 |


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

kube-api-auth had no documented versioning scheme.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Add VERSION.md establishing the versioning scheme: - The master minor is bumped to match the lowest Rancher minor the next release will serve (e.g. v0.13 for Rancher v2.13+).
- Maintenance lines for older Rancher versions live on release/v0.<MIN> branches with sequential patches (v0.<MIN>.0, v0.<MIN>.1, …).
- A machine-readable table maps each branch to its allowed minor and the Rancher versions it serves, with active/eol status.
- A "Currently deployed tags" table tracks which tag each Rancher minor is pinned to.

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
