### PR TITLE
Document the use of v0.13.0 tag and branching off release/v0.15

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -19,7 +19,8 @@ Keep the table well-formed: one row per branch, columns in the order shown.
 
 | Branch              | Minor   | Rancher Versions     | Status |
 |---------------------|---------|----------------------|--------|
-| main                | v0.15   | v2.15                | active |
+| main                | v0.16   | v2.16                | active |
+| release/v0.15       | v0.15   | v2.15                | active |
 | release/v0.13       | v0.13   | v2.13, v2.14         | active |
 | release/v0.10       | v0.10   | v2.10, v2.11, v2.12  | active |
 
@@ -38,5 +39,5 @@ authoritative for per-patch precision).
 
 | kube-api-auth Tag | Rancher Minors      |
 |-------------------|---------------------|
-| v0.2.6            | v2.13, v2.14, v2.15 |
+| v0.13.0           | v2.13, v2.14        |
 | v0.2.4            | v2.10, v2.11, v2.12 |


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- v0.13.0 is now used by v2.14 and v2.13 release lines
- release/v0.15 is branched off of v0.15.0-rc.2 to unlock changes for v2.16
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
