### PR TITLE
[v0.15] Port reliability and correctness fixes to release/v0.15

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	kubeapiauth "github.com/rancher/kube-api-auth/pkg"
 	"github.com/rancher/kube-api-auth/pkg/service"
@@ -87,5 +90,7 @@ func createToken(_ *cli.Context) error {
 }
 
 func startService(_ *cli.Context) error {
-	return service.Serve(appConfig.Listen, appConfig.Namespace, appConfig.Kubeconfig)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return service.Serve(ctx, appConfig.Listen, appConfig.Namespace, appConfig.Kubeconfig)
 }

--- a/pkg/service/handlers/v1-kube-api-authn.go
+++ b/pkg/service/handlers/v1-kube-api-authn.go
@@ -198,7 +198,10 @@ func (h *KubeAPIHandlers) v1getAndVerifyUser(accessKey, secretKey string) (*type
 			updated := clusterUserAttribute.DeepCopy()
 			updated.NeedsRefresh = true
 			if _, err := h.clusterUserAttribute.Update(updated); err != nil {
-				return nil, fmt.Errorf("error updating clusterUserAttribute %s: %w", clusterUserAttribute.Name, err)
+				// NeedsRefresh is a best-effort hint to the refresh
+				// controller and has no bearing on whether the token
+				// is authentic. Log and continue.
+				log.Errorf("error setting NeedsRefresh on clusterUserAttribute %s: %s", clusterUserAttribute.Name, err)
 			}
 		}
 	}

--- a/pkg/service/handlers/v1-kube-api-authn.go
+++ b/pkg/service/handlers/v1-kube-api-authn.go
@@ -163,12 +163,18 @@ func (h *KubeAPIHandlers) v1getAndVerifyUser(accessKey, secretKey string) (*type
 			}
 		}
 
-		// Update shadow token to complete the migration
+		// Update shadow token to complete the migration. DeepCopy the
+		// cache object to avoid mutating shared informer state, and
+		// re-assign the outer clusterAuthToken so the later
+		// LastUsedAt update doesn't send the pre-migration hash back.
+		clusterAuthTokenLocal = clusterAuthTokenLocal.DeepCopy()
 		clusterAuthTokenLocal.SecretKeyHash = "" // nolint:staticcheck
-		if _, err = h.clusterAuthTokens.Update(clusterAuthTokenLocal); err != nil {
+		updated, err := h.clusterAuthTokens.Update(clusterAuthTokenLocal)
+		if err != nil {
 			log.Errorf("error migrating clusterAuthToken %s: %s", clusterAuthTokenLocal.Name, err)
 			return err
 		}
+		clusterAuthToken = updated
 
 		return nil
 	})
@@ -189,8 +195,9 @@ func (h *KubeAPIHandlers) v1getAndVerifyUser(accessKey, secretKey string) (*type
 		}
 
 		if refresh.Add(refreshPeriod).Before(now) {
-			clusterUserAttribute.NeedsRefresh = true
-			if _, err := h.clusterUserAttribute.Update(clusterUserAttribute); err != nil {
+			updated := clusterUserAttribute.DeepCopy()
+			updated.NeedsRefresh = true
+			if _, err := h.clusterUserAttribute.Update(updated); err != nil {
 				return nil, fmt.Errorf("error updating clusterUserAttribute %s: %w", clusterUserAttribute.Name, err)
 			}
 		}
@@ -207,12 +214,13 @@ func (h *KubeAPIHandlers) v1getAndVerifyUser(accessKey, secretKey string) (*type
 			}
 		}
 
+		updated := clusterAuthToken.DeepCopy()
 		lastUsedAt := metav1.NewTime(now)
-		clusterAuthToken.LastUsedAt = &lastUsedAt
+		updated.LastUsedAt = &lastUsedAt
 
-		if _, err = h.clusterAuthTokens.Update(clusterAuthToken); err != nil {
+		if _, err = h.clusterAuthTokens.Update(updated); err != nil {
 			// Best-effort update. Don't retry or fail the request.
-			log.Errorf("error updating clusterAuthToken %s: %s", clusterAuthToken.Name, err)
+			log.Errorf("error updating clusterAuthToken %s: %s", updated.Name, err)
 		}
 	}()
 

--- a/pkg/service/handlers/v1-kube-api-authn.go
+++ b/pkg/service/handlers/v1-kube-api-authn.go
@@ -106,7 +106,20 @@ func (h *KubeAPIHandlers) v1getAndVerifyUser(accessKey, secretKey string) (*type
 	var clusterAuthToken *clusterv3.ClusterAuthToken
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		clusterAuthTokenLocal, err := h.clusterAuthTokensLister.Get(h.namespace, accessKey)
+		// After a 409 conflict the informer cache still holds the
+		// stale resourceVersion until the watch catches up, so a
+		// cache read here would loop with the same version and 409
+		// again until retries exhaust. First attempt reads from the
+		// cache for speed; retries fall back to a direct API Get.
+		var (
+			clusterAuthTokenLocal *clusterv3.ClusterAuthToken
+			err                   error
+		)
+		if clusterAuthToken == nil {
+			clusterAuthTokenLocal, err = h.clusterAuthTokensLister.Get(h.namespace, accessKey)
+		} else {
+			clusterAuthTokenLocal, err = h.clusterAuthTokens.GetNamespaced(h.namespace, accessKey, metav1.GetOptions{})
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/service/handlers/v1-kube-api-authn_test.go
+++ b/pkg/service/handlers/v1-kube-api-authn_test.go
@@ -871,7 +871,7 @@ func TestGetAndVerifyUser(t *testing.T) {
 		})
 	})
 
-	t.Run("user attribute update fails during refresh", func(t *testing.T) {
+	t.Run("user attribute update failure during refresh is silent", func(t *testing.T) {
 		t.Parallel()
 
 		synctest.Test(t, func(t *testing.T) {
@@ -905,11 +905,16 @@ func TestGetAndVerifyUser(t *testing.T) {
 						return nil, fmt.Errorf("update failed")
 					},
 				},
+				clusterAuthTokens: &clusterfakes.ClusterAuthTokenInterfaceMock{
+					UpdateFunc: func(in1 *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
+						return in1, nil
+					},
+				},
 			}
 
-			_, err := h.v1getAndVerifyUser(testAccessKey, testSecretKey)
-			require.Error(t, err)
-			assert.ErrorContains(t, err, "update failed")
+			result, err := h.v1getAndVerifyUser(testAccessKey, testSecretKey)
+			require.NoError(t, err)
+			assert.Equal(t, testUserName, result.UserName)
 		})
 	})
 

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -14,10 +16,19 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func Serve(listen, namespace, kubeConfig string) error {
-	log.Info("Starting Rancher Kube-API-Auth service on ", listen)
+const (
+	controllerWorkers = 5
+	cacheSyncTimeout  = 30 * time.Second
 
-	ctx := context.Background()
+	readHeaderTimeout = 10 * time.Second
+	readTimeout       = 30 * time.Second
+	writeTimeout      = 30 * time.Second
+	idleTimeout       = 120 * time.Second
+	shutdownTimeout   = 15 * time.Second
+)
+
+func Serve(ctx context.Context, listen, namespace, kubeConfig string) error {
+	log.Info("Starting Rancher Kube-API-Auth service on ", listen)
 
 	_, clientConfig, err := k8s.GetConfig(ctx, "auto", kubeConfig)
 	if err != nil {
@@ -36,29 +47,56 @@ func Serve(listen, namespace, kubeConfig string) error {
 	clusterAPI := clusterv3.NewFromControllerFactory(wranglerCtx.ControllerFactory)
 	coreAPI := corev1.NewFromControllerFactory(wranglerCtx.ControllerFactory)
 
-	// API framework routes
 	kubeAPIHandlers := handlers.NewKubeAPIHandlers(namespace, clusterAPI, coreAPI)
-	router := RouteContext(kubeAPIHandlers)
 
-	go func() {
-		for {
-			if err := wranglerCtx.ControllerFactory.Start(ctx, 5); err != nil {
-				log.Error(err)
-				time.Sleep(2 * time.Second)
-			} else {
-				break
-			}
+	log.Info("Starting controllers and waiting for caches to sync")
+	if err := wranglerCtx.ControllerFactory.Start(ctx, controllerWorkers); err != nil {
+		return fmt.Errorf("starting controllers: %w", err)
+	}
+
+	syncCtx, cancel := context.WithTimeout(ctx, cacheSyncTimeout)
+	defer cancel()
+	for gvk, synced := range wranglerCtx.ControllerFactory.SharedCacheFactory().WaitForCacheSync(syncCtx) {
+		if !synced {
+			return fmt.Errorf("informer for %s did not sync", gvk)
 		}
+	}
+
+	srv := &http.Server{
+		Addr:              listen,
+		Handler:           RouteContext(kubeAPIHandlers),
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+		close(errCh)
 	}()
 
-	return http.ListenAndServe(listen, router)
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		log.Info("Shutdown signal received, draining connections")
+	}
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancelShutdown()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("http server shutdown: %w", err)
+	}
+	return nil
 }
 
 func RouteContext(kubeAPIHandlers *handlers.KubeAPIHandlers) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	// Healthcheck endpoint
 	router.Methods("GET").Path("/healthcheck").Handler(handlers.HealthcheckHandler())
-	// V1 Authenticate endpoint
 	router.Methods("POST").Path("/v1/authenticate").Handler(kubeAPIHandlers.V1AuthenticateHandler())
 
 	return router


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Issues identified during a rewrite to decouple from rancher/rancher #97:
- The handler mutates informer-cache objects in place before every Update call (ClusterAuthToken.SecretKeyHash, LastUsedAt, ClusterUserAttribute.NeedsRefresh). These objects are shared across goroutines, so the writes race with other handlers reading the same cache entry.
- A 409 (or any error) from the NeedsRefresh Update propagates as an HTTP 401 for a token that is otherwise valid. NeedsRefresh is a best-effort hint to the refresh controller and has no bearing on the token's authenticity.
- The migration path's retry.RetryOnConflict re-reads the ClusterAuthToken from the informer cache on every iteration. After a real conflict the cache still holds the stale resourceVersion until the watch catches up, so every retry re-issues the same Update with the same version and gets another 409 until DefaultRetry exhausts.
- Serve runs the wrangler ControllerFactory.Start in a goroutine with an infinite retry loop and immediately calls http.ListenAndServe. HTTP accepts TokenReview requests before any informer cache is populated, so every legit token gets hash secret is missing until caches catch up. WaitForCacheSync failures are never surfaced. ListenAndServe has no read/write timeouts and no graceful shutdown, so SIGTERM from a rolling restart drops in-flight requests.

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- DeepCopy informer cache objects before Update. Three spots in `v1getAndVerifyUser` now DeepCopy before mutating. The migration path also re-assigns the outer clusterAuthToken to the returned value so the subsequent LastUsedAt update doesn't send the pre-migration hash back and undo the migration.
- Log and swallow `NeedsRefresh` update failures. Matches the existing behavior of the `LastUsedAt` update. Auth returns success on valid tokens even if the refresh-hint write fails.
- Fall back to the API server inside the secret migration retry. First attempt still reads from the cache (fast path). On subsequent iterations (detected by clusterAuthToken already being set) the retry uses `clusterAuthTokens.GetNamespaced(...)` so it sees a fresh resourceVersion and can complete.
- Gate HTTP on cache sync and add graceful shutdown. Serve now starts the controller factory synchronously and fails fast on error, iterates `SharedCacheFactory.WaitForCacheSync` within a
bounded timeout and returns an error naming any informer that didn't sync, builds the `http.Server` with named ReadHeaderTimeout / ReadTimeout / WriteTimeout / IdleTimeout, and calls `Shutdown(ctx)` on context cancel with a bounded drain window. main.go installs `signal.NotifyContext` for `SIGINT/SIGTERM`.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
