### PR TITLE
Refused token tokenreview response

### DIFF
--- a/pkg/api/v1/types/v1-authn-response.go
+++ b/pkg/api/v1/types/v1-authn-response.go
@@ -10,6 +10,7 @@ type V1AuthnResponseUser struct {
 type V1AuthnResponseStatus struct {
 	Authenticated bool                 `json:"authenticated"`
 	User          *V1AuthnResponseUser `json:"user,omitempty"`
+	Error         string               `json:"error,omitempty"`
 }
 
 type V1AuthnResponse struct {

--- a/pkg/service/handlers/authenticator.go
+++ b/pkg/service/handlers/authenticator.go
@@ -25,6 +25,15 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+// cannotVerifyError marks a failure that kept the handler from reaching a
+// verdict on a token, as opposed to a token that was checked and refused.
+// It is answered with a 5xx so the apiserver treats it as a webhook failure
+// and retries, rather than as a refusal of the token.
+type cannotVerifyError struct{ err error }
+
+func (e *cannotVerifyError) Error() string { return e.err.Error() }
+func (e *cannotVerifyError) Unwrap() error { return e.err }
+
 type Authenticator struct {
 	namespace                  string
 	clusterAuthTokens          clusterv3wr.ClusterAuthTokenClient
@@ -68,6 +77,10 @@ func (a *Authenticator) Authenticate(w http.ResponseWriter, r *http.Request) {
 
 	user, err := a.v1getAndVerifyUser(r.Context(), accessKey, secretKey)
 	if err != nil {
+		if _, ok := errors.AsType[*cannotVerifyError](err); ok {
+			ReturnHTTPError(w, r, http.StatusServiceUnavailable, fmt.Sprintf("%v", err))
+			return
+		}
 		// A refused token is a successful webhook call with a negative
 		// answer, so the apiserver expects a 2xx TokenReview with
 		// authenticated=false and the reason in status.error. A non-2xx
@@ -168,7 +181,7 @@ func (a *Authenticator) v1getAndVerifyUser(ctx context.Context, accessKey, secre
 	if migrate {
 		migrated, err := a.migrateHash(ctx, accessKey)
 		if err != nil {
-			return nil, err
+			return nil, &cannotVerifyError{err}
 		}
 		if migrated != nil {
 			clusterAuthToken = migrated

--- a/pkg/service/handlers/authenticator.go
+++ b/pkg/service/handlers/authenticator.go
@@ -68,13 +68,23 @@ func (a *Authenticator) Authenticate(w http.ResponseWriter, r *http.Request) {
 
 	user, err := a.v1getAndVerifyUser(r.Context(), accessKey, secretKey)
 	if err != nil {
-		ReturnHTTPError(w, r, http.StatusUnauthorized, fmt.Sprintf("%v", err))
+		// A refused token is a successful webhook call with a negative
+		// answer, so the apiserver expects a 2xx TokenReview with
+		// authenticated=false and the reason in status.error. A non-2xx
+		// here is treated by the apiserver as a webhook outage: it retries
+		// with backoff and logs "Failed to make webhook authenticator request".
+		log.Infof("Authentication refused for %s: %v", accessKey, err)
+		response.Status.Error = err.Error()
+		writeTokenReview(w, r, response)
 		return
 	}
 
 	response.Status.Authenticated = true
 	response.Status.User = user
+	writeTokenReview(w, r, response)
+}
 
+func writeTokenReview(w http.ResponseWriter, r *http.Request, response types.V1AuthnResponse) {
 	responseJSON, err := json.Marshal(response)
 	if err != nil {
 		ReturnHTTPError(w, r, http.StatusServiceUnavailable, fmt.Sprintf("%v", err))

--- a/pkg/service/handlers/authenticator.go
+++ b/pkg/service/handlers/authenticator.go
@@ -90,10 +90,12 @@ func writeTokenReview(w http.ResponseWriter, r *http.Request, response types.V1A
 		ReturnHTTPError(w, r, http.StatusServiceUnavailable, fmt.Sprintf("%v", err))
 		return
 	}
+
 	w.Header().Set("Content-Type", "application/json")
 	if _, err := w.Write(responseJSON); err != nil {
-		ReturnHTTPError(w, r, http.StatusServiceUnavailable, fmt.Sprintf("%v", err))
-		return
+		// The status line and headers went out with the first byte of
+		// the body, so nothing more can be sent to the client.
+		log.Errorf("error writing TokenReview response: %v", err)
 	}
 }
 

--- a/pkg/service/handlers/authenticator.go
+++ b/pkg/service/handlers/authenticator.go
@@ -90,6 +90,7 @@ func writeTokenReview(w http.ResponseWriter, r *http.Request, response types.V1A
 		ReturnHTTPError(w, r, http.StatusServiceUnavailable, fmt.Sprintf("%v", err))
 		return
 	}
+	w.Header().Set("Content-Type", "application/json")
 	if _, err := w.Write(responseJSON); err != nil {
 		ReturnHTTPError(w, r, http.StatusServiceUnavailable, fmt.Sprintf("%v", err))
 		return

--- a/pkg/service/handlers/authenticator_test.go
+++ b/pkg/service/handlers/authenticator_test.go
@@ -1236,23 +1236,89 @@ func TestAuthenticate(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
-	t.Run("invalid credentials returns 401", func(t *testing.T) {
+	t.Run("refused token returns 200 with authenticated false and error", func(t *testing.T) {
 		t.Parallel()
 
-		h := &Authenticator{
-			namespace: testNamespace,
-			clusterAuthTokensCache: &fakeClusterAuthTokenCache{
-				GetFunc: func(ns, name string) (*clusterv3.ClusterAuthToken, error) {
+		expiredToken := newTestToken()
+		expiredToken.ExpiresAt = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+
+		disabledToken := newTestToken()
+		disabledToken.Enabled = false
+
+		tests := []struct {
+			name    string
+			token   string
+			get     func(ns, name string) (*clusterv3.ClusterAuthToken, error)
+			wantErr string
+		}{
+			{
+				name:  "unknown token",
+				token: "unknown-token:secret",
+				get: func(ns, name string) (*clusterv3.ClusterAuthToken, error) {
 					return nil, notFound(name)
 				},
+				wantErr: "not found",
+			},
+			{
+				name:  "wrong secret",
+				token: testAccessKey + ":wrong-secret",
+				get: func(ns, name string) (*clusterv3.ClusterAuthToken, error) {
+					return newTestToken(), nil
+				},
+				wantErr: "secretKey hash does not match",
+			},
+			{
+				name:  "expired token",
+				token: testAccessKey + ":" + testSecretKey,
+				get: func(ns, name string) (*clusterv3.ClusterAuthToken, error) {
+					return expiredToken, nil
+				},
+				wantErr: "auth expired at",
+			},
+			{
+				name:  "disabled token",
+				token: testAccessKey + ":" + testSecretKey,
+				get: func(ns, name string) (*clusterv3.ClusterAuthToken, error) {
+					return disabledToken, nil
+				},
+				wantErr: "token is not enabled",
 			},
 		}
 
-		w := httptest.NewRecorder()
-		r := tokenReviewRequest(t, "unknown-token:secret")
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 
-		h.Authenticate(w, r)
+				h := &Authenticator{
+					namespace:              testNamespace,
+					clusterAuthTokensCache: &fakeClusterAuthTokenCache{GetFunc: tt.get},
+					clusterUserAttributesCache: &fakeClusterUserAttributeCache{
+						GetFunc: func(ns, name string) (*clusterv3.ClusterUserAttribute, error) {
+							return newTestUser(), nil
+						},
+					},
+					secretLister: &fakeSecretLister{
+						GetFunc: func(name string) (*corev1.Secret, error) {
+							return newTestSecret(), nil
+						},
+					},
+				}
 
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
+				w := httptest.NewRecorder()
+				r := tokenReviewRequest(t, tt.token)
+
+				h.Authenticate(w, r)
+
+				assert.Equal(t, http.StatusOK, w.Code)
+
+				var resp types.V1AuthnResponse
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				assert.Equal(t, kubeapiauth.DefaultK8sAPIVersion, resp.APIVersion)
+				assert.Equal(t, kubeapiauth.DefaultAuthnKind, resp.Kind)
+				assert.False(t, resp.Status.Authenticated)
+				assert.Nil(t, resp.Status.User)
+				assert.Contains(t, resp.Status.Error, tt.wantErr)
+			})
+		}
 	})
 }

--- a/pkg/service/handlers/authenticator_test.go
+++ b/pkg/service/handlers/authenticator_test.go
@@ -548,6 +548,8 @@ func TestGetAndVerifyUser(t *testing.T) {
 		_, err := h.v1getAndVerifyUser(t.Context(), testAccessKey, "wrong-secret")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "does not match")
+		var cannotVerify *cannotVerifyError
+		assert.NotErrorAs(t, err, &cannotVerify)
 	})
 
 	t.Run("expired token", func(t *testing.T) {
@@ -765,6 +767,8 @@ func TestGetAndVerifyUser(t *testing.T) {
 		_, err := h.v1getAndVerifyUser(t.Context(), testAccessKey, testSecretKey)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "storage unavailable")
+		var cannotVerify *cannotVerifyError
+		assert.ErrorAs(t, err, &cannotVerify)
 	})
 
 	t.Run("migration token update fails", func(t *testing.T) {
@@ -807,6 +811,8 @@ func TestGetAndVerifyUser(t *testing.T) {
 
 		_, err := h.v1getAndVerifyUser(t.Context(), testAccessKey, testSecretKey)
 		require.Error(t, err)
+		var cannotVerify *cannotVerifyError
+		assert.ErrorAs(t, err, &cannotVerify)
 	})
 
 	t.Run("refresh triggered when overdue", func(t *testing.T) {
@@ -1255,6 +1261,50 @@ func TestAuthenticate(t *testing.T) {
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	})
+
+	t.Run("migration failure returns 503", func(t *testing.T) {
+		t.Parallel()
+
+		token := newTestToken()
+		token.SecretKeyHash = testSecretKeyHash //nolint:staticcheck
+
+		h := &Authenticator{
+			namespace: testNamespace,
+			clusterAuthTokensCache: &fakeClusterAuthTokenCache{
+				GetFunc: func(ns, name string) (*clusterv3.ClusterAuthToken, error) {
+					return token, nil
+				},
+			},
+			clusterUserAttributesCache: &fakeClusterUserAttributeCache{
+				GetFunc: func(ns, name string) (*clusterv3.ClusterUserAttribute, error) {
+					return newTestUser(), nil
+				},
+			},
+			secretLister: &fakeSecretLister{
+				GetFunc: func(name string) (*corev1.Secret, error) {
+					return nil, notFound(name)
+				},
+			},
+			secrets: &fakeSecretClient{
+				CreateFunc: func(ctx context.Context, s *corev1.Secret, opts metav1.CreateOptions) (*corev1.Secret, error) {
+					return nil, fmt.Errorf("storage unavailable")
+				},
+			},
+			clusterAuthTokens: &fakeClusterAuthTokenClient{
+				GetFunc: func(ns, name string, opts metav1.GetOptions) (*clusterv3.ClusterAuthToken, error) {
+					return token, nil
+				},
+			},
+		}
+
+		w := httptest.NewRecorder()
+		r := tokenReviewRequest(t, testAccessKey+":"+testSecretKey)
+
+		h.Authenticate(w, r)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+		assert.Empty(t, w.Body.Bytes())
 	})
 
 	t.Run("failed body write does not rewrite status", func(t *testing.T) {

--- a/pkg/service/handlers/authenticator_test.go
+++ b/pkg/service/handlers/authenticator_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -186,6 +187,24 @@ func noRefreshConfigMap() *fakeConfigMapLister {
 			return nil, notFound(name)
 		},
 	}
+}
+
+// failingResponseWriter fails every Write and records WriteHeader calls, so a
+// test can assert that a handler does not try to change the status after the
+// body write has already committed the response.
+type failingResponseWriter struct {
+	header      http.Header
+	statusCodes []int
+}
+
+func (f *failingResponseWriter) Header() http.Header { return f.header }
+
+func (f *failingResponseWriter) Write([]byte) (int, error) {
+	return 0, errors.New("client went away")
+}
+
+func (f *failingResponseWriter) WriteHeader(statusCode int) {
+	f.statusCodes = append(f.statusCodes, statusCode)
 }
 
 func TestV1parseBody(t *testing.T) {
@@ -1236,6 +1255,27 @@ func TestAuthenticate(t *testing.T) {
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	})
+
+	t.Run("failed body write does not rewrite status", func(t *testing.T) {
+		t.Parallel()
+
+		h := &Authenticator{
+			namespace: testNamespace,
+			clusterAuthTokensCache: &fakeClusterAuthTokenCache{
+				GetFunc: func(ns, name string) (*clusterv3.ClusterAuthToken, error) {
+					return nil, notFound(name)
+				},
+			},
+		}
+
+		w := &failingResponseWriter{header: http.Header{}}
+		r := tokenReviewRequest(t, "unknown-token:secret")
+
+		h.Authenticate(w, r)
+
+		assert.Empty(t, w.statusCodes)
+		assert.Equal(t, "application/json", w.header.Get("Content-Type"))
 	})
 
 	t.Run("refused token returns 200 with authenticated false and error", func(t *testing.T) {

--- a/pkg/service/handlers/authenticator_test.go
+++ b/pkg/service/handlers/authenticator_test.go
@@ -1211,6 +1211,7 @@ func TestAuthenticate(t *testing.T) {
 			h.Authenticate(w, r)
 
 			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 
 			var resp types.V1AuthnResponse
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -1234,6 +1235,7 @@ func TestAuthenticate(t *testing.T) {
 		h.Authenticate(w, r)
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 	})
 
 	t.Run("refused token returns 200 with authenticated false and error", func(t *testing.T) {
@@ -1310,6 +1312,7 @@ func TestAuthenticate(t *testing.T) {
 				h.Authenticate(w, r)
 
 				assert.Equal(t, http.StatusOK, w.Code)
+				assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 
 				var resp types.V1AuthnResponse
 				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))

--- a/pkg/service/handlers/httperror_test.go
+++ b/pkg/service/handlers/httperror_test.go
@@ -20,6 +20,7 @@ func TestReturnHTTPError(t *testing.T) {
 		ReturnHTTPError(w, r, http.StatusUnauthorized, "invalid credentials")
 
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
 	})
 
 	t.Run("bad request", func(t *testing.T) {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/57218 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

A refused token (unknown, wrong secret, expired, disabled) was answered with an empty HTTP 401. The kube-apiserver treats any non-2xx from the webhook as a failed call: it retries with backoff, logs `Failed to make webhook authenticator request`, and counts the request as a webhook failure in `apiserver_webhook_authentication_request_total`. A stale kubeconfig was indistinguishable from a broken kube-api-auth in those signals.

The same response path had two smaller defects. TokenReview responses were written without a `Content-Type` header, so Go sniffed the body and reported `text/plain`. A failed body write was answered with a 503 after the status line had already gone out, which only triggered a superfluous `WriteHeader` warning.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

A refused token is now answered with HTTP 200 and a TokenReview carrying `authenticated: false` and the verification error in `status.error`, as the webhook contract describes. The apiserver reports the refusal as a refusal and records a 200. Malformed bodies still get 400.

A failed hash migration is the one case where verification could not complete: the token had already passed the hash check and the failure came from a live API call. It is now marked with a `cannotVerifyError` and answered with 503, which the apiserver retries. Every other verification error is a refusal.

TokenReview responses now set `Content-Type: application/json`. A failed body write is logged and nothing else is sent.

Handler tests cover the four refusal cases, the malformed body, the 503 on migration failure, the header on every path, and the failed body write. 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests