### PR TITLE
Answer a TokenReview in the apiVersion the apiserver sent

### DIFF
--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -1,7 +1,9 @@
 package kubeapiauth
 
 const (
-	DefaultK8sAPIVersion  = "authentication.k8s.io/v1beta1"
+	K8sAPIVersionV1       = "authentication.k8s.io/v1"
+	K8sAPIVersionV1beta1  = "authentication.k8s.io/v1beta1"
+	DefaultK8sAPIVersion  = K8sAPIVersionV1beta1
 	DefaultAuthnKind      = "TokenReview"
 	DefaultNamespace      = "cattle-system"
 	DefaultListenHostPort = "127.0.0.1:6440"

--- a/pkg/service/handlers/authenticator.go
+++ b/pkg/service/handlers/authenticator.go
@@ -58,24 +58,33 @@ func NewAuthenticator(namespace string, c *clients.Clients) *Authenticator {
 	}
 }
 
+// authnRequest is the parsed TokenReview the apiserver sent. The apiVersion is
+// kept because the apiserver only decodes a reply that carries the same
+// version it sent; a v1 apiserver rejects a v1beta1 reply and vice versa.
+type authnRequest struct {
+	apiVersion string
+	accessKey  string
+	secretKey  string
+}
+
 func (a *Authenticator) Authenticate(w http.ResponseWriter, r *http.Request) {
+	req, err := v1parseBody(r)
+	if err != nil {
+		ReturnHTTPError(w, r, http.StatusBadRequest, fmt.Sprintf("%v", err))
+		return
+	}
+
 	response := types.V1AuthnResponse{
-		APIVersion: kubeapiauth.DefaultK8sAPIVersion,
+		APIVersion: req.apiVersion,
 		Kind:       kubeapiauth.DefaultAuthnKind,
 		Status: types.V1AuthnResponseStatus{
 			Authenticated: false,
 		},
 	}
 
-	accessKey, secretKey, err := v1parseBody(r)
-	if err != nil {
-		ReturnHTTPError(w, r, http.StatusBadRequest, fmt.Sprintf("%v", err))
-		return
-	}
+	log.Debugf("Processing authentication request for %s", req.accessKey)
 
-	log.Debugf("Processing authentication request for %s", accessKey)
-
-	user, err := a.v1getAndVerifyUser(r.Context(), accessKey, secretKey)
+	user, err := a.v1getAndVerifyUser(r.Context(), req.accessKey, req.secretKey)
 	if err != nil {
 		if _, ok := errors.AsType[*cannotVerifyError](err); ok {
 			ReturnHTTPError(w, r, http.StatusServiceUnavailable, fmt.Sprintf("%v", err))
@@ -86,7 +95,7 @@ func (a *Authenticator) Authenticate(w http.ResponseWriter, r *http.Request) {
 		// authenticated=false and the reason in status.error. A non-2xx
 		// here is treated by the apiserver as a webhook outage: it retries
 		// with backoff and logs "Failed to make webhook authenticator request".
-		log.Infof("Authentication refused for %s: %v", accessKey, err)
+		log.Infof("Authentication refused for %s: %v", req.accessKey, err)
 		response.Status.Error = err.Error()
 		writeTokenReview(w, r, response)
 		return
@@ -112,26 +121,27 @@ func writeTokenReview(w http.ResponseWriter, r *http.Request, response types.V1A
 	}
 }
 
-func v1parseBody(r *http.Request) (string, string, error) {
+func v1parseBody(r *http.Request) (authnRequest, error) {
 	bytes, err := io.ReadAll(r.Body)
 	if err != nil {
-		return "", "", err
+		return authnRequest{}, err
 	}
 
 	authnReq, err := v1getBodyAuthnRequest(bytes)
 	if err != nil {
-		return "", "", err
+		return authnRequest{}, err
 	}
 
 	tokenParts := strings.SplitN(authnReq.Spec.Token, ":", 2)
 	if len(tokenParts) != 2 {
-		return "", "", fmt.Errorf("found %d parts of token", len(tokenParts))
+		return authnRequest{}, fmt.Errorf("found %d parts of token", len(tokenParts))
 	}
 
-	accessKey := strings.TrimPrefix(tokenParts[0], "ext/")
-	secretKey := tokenParts[1]
-
-	return accessKey, secretKey, nil
+	return authnRequest{
+		apiVersion: authnReq.APIVersion,
+		accessKey:  strings.TrimPrefix(tokenParts[0], "ext/"),
+		secretKey:  tokenParts[1],
+	}, nil
 }
 
 func v1getBodyAuthnRequest(bytes []byte) (*types.V1AuthnRequest, error) {
@@ -142,6 +152,16 @@ func v1getBodyAuthnRequest(bytes []byte) (*types.V1AuthnRequest, error) {
 
 	if authnReq.Kind != kubeapiauth.DefaultAuthnKind {
 		return nil, errors.New("authentication request kind is not TokenReview")
+	}
+
+	switch authnReq.APIVersion {
+	case kubeapiauth.K8sAPIVersionV1, kubeapiauth.K8sAPIVersionV1beta1:
+	case "":
+		// The apiserver always sends a version; tolerate hand-built
+		// requests the way earlier releases did.
+		authnReq.APIVersion = kubeapiauth.DefaultK8sAPIVersion
+	default:
+		return nil, fmt.Errorf("authentication request apiVersion %q is not supported", authnReq.APIVersion)
 	}
 
 	if authnReq.Spec.Token == "" {

--- a/pkg/service/handlers/authenticator_test.go
+++ b/pkg/service/handlers/authenticator_test.go
@@ -51,9 +51,14 @@ func TestMain(m *testing.M) {
 
 func tokenReviewRequest(t *testing.T, token string) *http.Request {
 	t.Helper()
+	return tokenReviewRequestWithVersion(t, kubeapiauth.DefaultK8sAPIVersion, token)
+}
+
+func tokenReviewRequestWithVersion(t *testing.T, apiVersion, token string) *http.Request {
+	t.Helper()
 
 	body := types.V1AuthnRequest{
-		APIVersion: kubeapiauth.DefaultK8sAPIVersion,
+		APIVersion: apiVersion,
 		Kind:       kubeapiauth.DefaultAuthnKind,
 		Spec:       types.V1AuthnRequestSpec{Token: token},
 	}
@@ -238,10 +243,42 @@ func TestV1parseBody(t *testing.T) {
 				t.Parallel()
 
 				r := tokenReviewRequest(t, tt.token)
-				accessKey, secretKey, err := v1parseBody(r)
+				req, err := v1parseBody(r)
 				require.NoError(t, err)
-				assert.Equal(t, tt.wantKey, accessKey)
-				assert.Equal(t, tt.wantSecret, secretKey)
+				assert.Equal(t, tt.wantKey, req.accessKey)
+				assert.Equal(t, tt.wantSecret, req.secretKey)
+			})
+		}
+	})
+
+	t.Run("apiVersion", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name        string
+			apiVersion  string
+			wantVersion string
+			wantErr     string
+		}{
+			{name: "v1", apiVersion: kubeapiauth.K8sAPIVersionV1, wantVersion: kubeapiauth.K8sAPIVersionV1},
+			{name: "v1beta1", apiVersion: kubeapiauth.K8sAPIVersionV1beta1, wantVersion: kubeapiauth.K8sAPIVersionV1beta1},
+			{name: "empty defaults to v1beta1", apiVersion: "", wantVersion: kubeapiauth.K8sAPIVersionV1beta1},
+			{name: "unsupported", apiVersion: "authentication.k8s.io/v2", wantErr: "not supported"},
+			{name: "wrong group", apiVersion: "authorization.k8s.io/v1", wantErr: "not supported"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				r := tokenReviewRequestWithVersion(t, tt.apiVersion, "key:secret")
+				req, err := v1parseBody(r)
+				if tt.wantErr != "" {
+					require.ErrorContains(t, err, tt.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantVersion, req.apiVersion)
 			})
 		}
 	})
@@ -251,7 +288,7 @@ func TestV1parseBody(t *testing.T) {
 
 		r := tokenReviewRequest(t, "nocolonhere")
 
-		_, _, err := v1parseBody(r)
+		_, err := v1parseBody(r)
 		require.ErrorContains(t, err, "found 1 parts of token")
 	})
 
@@ -260,7 +297,7 @@ func TestV1parseBody(t *testing.T) {
 
 		r := httptest.NewRequest(http.MethodPost, "/v1/authenticate", strings.NewReader(""))
 
-		_, _, err := v1parseBody(r)
+		_, err := v1parseBody(r)
 		require.ErrorContains(t, err, "unexpected end of JSON input")
 	})
 
@@ -269,7 +306,7 @@ func TestV1parseBody(t *testing.T) {
 
 		r := httptest.NewRequest(http.MethodPost, "/v1/authenticate", strings.NewReader("{invalid"))
 
-		_, _, err := v1parseBody(r)
+		_, err := v1parseBody(r)
 		require.ErrorContains(t, err, "invalid character")
 	})
 
@@ -284,7 +321,7 @@ func TestV1parseBody(t *testing.T) {
 		require.NoError(t, err)
 		r := httptest.NewRequest(http.MethodPost, "/v1/authenticate", bytes.NewReader(data))
 
-		_, _, err = v1parseBody(r)
+		_, err = v1parseBody(r)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "not TokenReview")
 	})
@@ -300,7 +337,7 @@ func TestV1parseBody(t *testing.T) {
 		require.NoError(t, err)
 		r := httptest.NewRequest(http.MethodPost, "/v1/authenticate", bytes.NewReader(data))
 
-		_, _, err = v1parseBody(r)
+		_, err = v1parseBody(r)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "missing Token")
 	})
@@ -1201,52 +1238,67 @@ func TestGetAndVerifyUser(t *testing.T) {
 func TestAuthenticate(t *testing.T) {
 	t.Parallel()
 
-	t.Run("valid request returns authenticated response", func(t *testing.T) {
+	for _, apiVersion := range []string{kubeapiauth.K8sAPIVersionV1, kubeapiauth.K8sAPIVersionV1beta1} {
+		t.Run("valid "+apiVersion+" request returns authenticated response", func(t *testing.T) {
+			t.Parallel()
+
+			synctest.Test(t, func(t *testing.T) {
+				h := &Authenticator{
+					namespace: testNamespace,
+					clusterAuthTokensCache: &fakeClusterAuthTokenCache{
+						GetFunc: func(ns, name string) (*clusterv3.ClusterAuthToken, error) {
+							return newTestToken(), nil
+						},
+					},
+					clusterUserAttributesCache: &fakeClusterUserAttributeCache{
+						GetFunc: func(ns, name string) (*clusterv3.ClusterUserAttribute, error) {
+							return newTestUser("group1"), nil
+						},
+					},
+					secretLister: &fakeSecretLister{
+						GetFunc: func(name string) (*corev1.Secret, error) {
+							return newTestSecret(), nil
+						},
+					},
+					configMapLister: noRefreshConfigMap(),
+					clusterAuthTokens: &fakeClusterAuthTokenClient{
+						UpdateFunc: func(obj *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
+							return obj, nil
+						},
+					},
+				}
+
+				w := httptest.NewRecorder()
+				r := tokenReviewRequestWithVersion(t, apiVersion, testAccessKey+":"+testSecretKey)
+
+				h.Authenticate(w, r)
+
+				assert.Equal(t, http.StatusOK, w.Code)
+				assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+				var resp types.V1AuthnResponse
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				assert.Equal(t, apiVersion, resp.APIVersion)
+				assert.Equal(t, kubeapiauth.DefaultAuthnKind, resp.Kind)
+				assert.True(t, resp.Status.Authenticated)
+				require.NotNil(t, resp.Status.User)
+				assert.Equal(t, testUserName, resp.Status.User.UserName)
+				assert.Equal(t, []string{"group1"}, resp.Status.User.Groups)
+			})
+		})
+	}
+
+	t.Run("unsupported apiVersion returns 400", func(t *testing.T) {
 		t.Parallel()
 
-		synctest.Test(t, func(t *testing.T) {
-			h := &Authenticator{
-				namespace: testNamespace,
-				clusterAuthTokensCache: &fakeClusterAuthTokenCache{
-					GetFunc: func(ns, name string) (*clusterv3.ClusterAuthToken, error) {
-						return newTestToken(), nil
-					},
-				},
-				clusterUserAttributesCache: &fakeClusterUserAttributeCache{
-					GetFunc: func(ns, name string) (*clusterv3.ClusterUserAttribute, error) {
-						return newTestUser("group1"), nil
-					},
-				},
-				secretLister: &fakeSecretLister{
-					GetFunc: func(name string) (*corev1.Secret, error) {
-						return newTestSecret(), nil
-					},
-				},
-				configMapLister: noRefreshConfigMap(),
-				clusterAuthTokens: &fakeClusterAuthTokenClient{
-					UpdateFunc: func(obj *clusterv3.ClusterAuthToken) (*clusterv3.ClusterAuthToken, error) {
-						return obj, nil
-					},
-				},
-			}
+		h := &Authenticator{}
 
-			w := httptest.NewRecorder()
-			r := tokenReviewRequest(t, testAccessKey+":"+testSecretKey)
+		w := httptest.NewRecorder()
+		r := tokenReviewRequestWithVersion(t, "authentication.k8s.io/v2", testAccessKey+":"+testSecretKey)
 
-			h.Authenticate(w, r)
+		h.Authenticate(w, r)
 
-			assert.Equal(t, http.StatusOK, w.Code)
-			assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
-
-			var resp types.V1AuthnResponse
-			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-			assert.Equal(t, kubeapiauth.DefaultK8sAPIVersion, resp.APIVersion)
-			assert.Equal(t, kubeapiauth.DefaultAuthnKind, resp.Kind)
-			assert.True(t, resp.Status.Authenticated)
-			require.NotNil(t, resp.Status.User)
-			assert.Equal(t, testUserName, resp.Status.User.UserName)
-			assert.Equal(t, []string{"group1"}, resp.Status.User.Groups)
-		})
+		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
 	t.Run("malformed body returns 400", func(t *testing.T) {
@@ -1397,7 +1449,7 @@ func TestAuthenticate(t *testing.T) {
 				}
 
 				w := httptest.NewRecorder()
-				r := tokenReviewRequest(t, tt.token)
+				r := tokenReviewRequestWithVersion(t, kubeapiauth.K8sAPIVersionV1, tt.token)
 
 				h.Authenticate(w, r)
 
@@ -1406,7 +1458,7 @@ func TestAuthenticate(t *testing.T) {
 
 				var resp types.V1AuthnResponse
 				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-				assert.Equal(t, kubeapiauth.DefaultK8sAPIVersion, resp.APIVersion)
+				assert.Equal(t, kubeapiauth.K8sAPIVersionV1, resp.APIVersion)
 				assert.Equal(t, kubeapiauth.DefaultAuthnKind, resp.Kind)
 				assert.False(t, resp.Status.Authenticated)
 				assert.Nil(t, resp.Status.User)


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/51442 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Every TokenReview reply carried apiVersion authentication.k8s.io/v1beta1 regardless of the request. The kube-apiserver decodes the reply with a codec fixed to the version named by `--authentication-token-webhook-version` and rejects a mismatch with "unknown conversion". With the flag set to v1, every login at the Authorized Cluster Endpoint failed.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The request apiVersion is now validated and echoed in the reply. Both `authentication.k8s.io/v1` and `v1beta1` are accepted; an empty `apiVersion` keeps the old `v1beta1` default; any other value is a 400. Tests cover both versions on the success and refusal paths and the rejected version.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests